### PR TITLE
fix issue with whitespaces in volume names

### DIFF
--- a/macbac.sh
+++ b/macbac.sh
@@ -196,7 +196,7 @@ disable() {
 }
 
 getVolumes() {
-    ls -d /Volumes/*
+    ls -1d /Volumes/*
 }
 
 getSnapshots() {
@@ -222,9 +222,13 @@ listStatus() {
 }
 
 listSnapshots() {
-    volumes=$(getVolumes)
+    declare -a volumes
 
-    for volume in $(getVolumes); do
+    while read -r line; do
+        volumes+=("$line") 
+    done <<< $(getVolumes)
+
+    for volume in "${volumes[@]}"; do
         # show current volume
         echo -e "${BOLD}${volume}${NC}"
 


### PR DESCRIPTION
this is a fix for this bug: `getVolumes()` doesn't work when there's a whitespace in a volume name (i.e. `/Volumes/Macintosh HD`).

to reproduce:
```
$ ls /Volumes
Macintosh HD
$ macbac list
/Volumes/Macintosh
/Volumes/Macintosh is not a valid disk
HD
HD is not a valid disk
```

with this pr:
```
$ macbac list
/Volumes/Macintosh HD
> 2021/02/13 20:23:32
```